### PR TITLE
Add before option

### DIFF
--- a/cmd/redhat.go
+++ b/cmd/redhat.go
@@ -22,11 +22,16 @@ func init() {
 	redhatCmd.PersistentFlags().String("after", "", "Fetch CVEs after the specified date (e.g. 2017-01-01) (default: 1970-01-01)")
 	viper.BindPFlag("after", redhatCmd.PersistentFlags().Lookup("after"))
 	viper.SetDefault("after", "1970-01-01")
+
+	redhatCmd.PersistentFlags().String("before", "", "Fetch CVEs before the specified date (e.g. 2017-01-01)")
+	viper.BindPFlag("before", redhatCmd.PersistentFlags().Lookup("before"))
+	viper.SetDefault("before", "")
 }
 
 func fetchRedhat(cmd *cobra.Command, args []string) (err error) {
 	log.Infof("Fetch the list of CVEs")
-	entries, err := fetcher.ListAllRedhatCves(viper.GetString("after"))
+	entries, err := fetcher.ListAllRedhatCves(
+		viper.GetString("before"), viper.GetString("after"))
 	var resourceURLs []string
 	for _, entry := range entries {
 		resourceURLs = append(resourceURLs, entry.ResourceURL)

--- a/fetcher/redhat.go
+++ b/fetcher/redhat.go
@@ -10,8 +10,12 @@ import (
 
 // ListAllRedhatCves returns the list of all CVEs from RedHat API
 // https://access.redhat.com/documentation/en-us/red_hat_security_data_api/0.1/html-single/red_hat_security_data_api/#list_all_cves
-func ListAllRedhatCves(after string) (entries []models.RedhatEntry, err error) {
+func ListAllRedhatCves(before, after string) (entries []models.RedhatEntry, err error) {
 	url := fmt.Sprintf("https://access.redhat.com/labs/securitydataapi/cve.json?after=%s&per_page=100000", after)
+	if before != "" {
+		url += fmt.Sprintf("&before=%s", before)
+
+	}
 	body, err := util.FetchURL(url)
 	if err != nil {
 		return entries, fmt.Errorf("Failed to fetch RedHat CVEs list: %v, url: %s", err, url)


### PR DESCRIPTION
Add `--before` option to `fetch redhat` command.

https://access.redhat.com/documentation/en-us/red_hat_security_data_api/0.1/html-single/red_hat_security_data_api/#cve
```
CVEs before the query date. [ISO 8601 is the expected format]
```