### PR TITLE
fix(db): chagne RDB column type to text

### DIFF
--- a/cmd/debian.go
+++ b/cmd/debian.go
@@ -33,6 +33,8 @@ func fetchDebian(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("Fetched all CVEs from Debian")
 	cves, err := fetcher.RetrieveDebianCveDetails()
 
+	log15.Info("Fetched", "CVEs", len(cves))
+
 	log15.Info("Insert Debian CVEs into DB", "db", driver.Name())
 	if err := driver.InsertDebian(cves); err != nil {
 		log15.Error("Failed to insert.", "dbpath",

--- a/models/debian.go
+++ b/models/debian.go
@@ -22,7 +22,7 @@ type DebianCVE struct {
 	ID          int64
 	CveID       string
 	Scope       string
-	Description string
+	Description string `sql:"type:text"`
 	Package     []DebianPackage
 }
 

--- a/models/redhat.go
+++ b/models/redhat.go
@@ -70,13 +70,13 @@ type RedhatCVE struct {
 	Cvss3                RedhatCvss3
 	Iava                 string
 	Cwe                  string
-	Statement            string
-	Acknowledgement      string
-	Mitigation           string
+	Statement            string `sql:"type:text"`
+	Acknowledgement      string `sql:"type:text"`
+	Mitigation           string `sql:"type:text"`
 	AffectedRelease      []RedhatAffectedRelease
 	PackageState         []RedhatPackageState
 	Name                 string
-	DocumentDistribution string
+	DocumentDistribution string `sql:"type:text"`
 
 	Details    []RedhatDetail    `json:",omitempty"`
 	References []RedhatReference `json:",omitempty"`
@@ -105,20 +105,21 @@ func (r RedhatCVE) GetPackages(sep string) (result string) {
 }
 
 type RedhatDetail struct {
-	RedhatCVEID int64 `sql:"type:bigint REFERENCES redhat_cves(id)" json:",omitempty"`
-	Detail      string
+	RedhatCVEID int64  `sql:"type:bigint REFERENCES redhat_cves(id)" json:",omitempty"`
+	Detail      string `sql:"type:text"`
 }
 
 type RedhatReference struct {
-	RedhatCVEID int64 `sql:"type:bigint REFERENCES redhat_cves(id)" json:",omitempty"`
-	Reference   string
+	RedhatCVEID int64  `sql:"type:bigint REFERENCES redhat_cves(id)" json:",omitempty"`
+	Reference   string `sql:"type:text"`
 }
 
 type RedhatBugzilla struct {
 	RedhatCVEID int64  `sql:"type:bigint REFERENCES redhat_cves(id)" json:",omitempty"`
-	Description string `json:"description"`
-	BugzillaID  string `json:"id"`
-	URL         string `json:"url"`
+	Description string `json:"description" sql:"type:text"`
+
+	BugzillaID string `json:"id"`
+	URL        string `json:"url"`
 }
 
 type RedhatCvss struct {


### PR DESCRIPTION
An error occurred while fetching NVD feed with MySQL backend.

```
Error 1406: Data too long for column 'description' at row
```

Change from Varcar fixed length type to text type.