### PR TITLE
Specify VOLUME using json syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --no-cache ca-certificates \
 
 COPY --from=builder /go/bin/gost /usr/local/bin/
 
-VOLUME [$WORKDIR, $LOGDIR]
+VOLUME ["$WORKDIR", "$LOGDIR"]
 WORKDIR $WORKDIR
 ENV PWD $WORKDIR
 


### PR DESCRIPTION
When using a json array for VOLUME, values must be quoted. Else it's interpreted as a string, eg /[vuls

Relates to: https://github.com/kotakanbe/goval-dictionary/issues/58