### PR TITLE
Fix issue with 'RedhatCVEJSON.mitigation' field

### DIFF
--- a/db/redhat.go
+++ b/db/redhat.go
@@ -219,7 +219,7 @@ func ConvertRedhat(cveJSONs []models.RedhatCVEJSON) (cves []models.RedhatCVE, er
 			Cwe:                  cve.Cwe,
 			Statement:            cve.Statement,
 			Acknowledgement:      cve.Acknowledgement,
-			Mitigation:           cve.Mitigation,
+			Mitigation:           cve.Mitigation.Value,
 			AffectedRelease:      cve.AffectedRelease,
 			PackageState:         cve.PackageState,
 			Name:                 cve.Name,

--- a/fetcher/redhat.go
+++ b/fetcher/redhat.go
@@ -135,6 +135,10 @@ func FetchRedHatVulnList() (entries []models.RedhatCVEJSON, err error) {
 			})
 		}
 
+		mitigation := models.RedhatMitigation{
+			Value: c.Mitigation,
+		}
+
 		entries = append(entries, models.RedhatCVEJSON{
 			ThreatSeverity:       c.ThreatSeverity,
 			PublicDate:           c.PublicDate,
@@ -145,7 +149,7 @@ func FetchRedHatVulnList() (entries []models.RedhatCVEJSON, err error) {
 			Cwe:                  c.Cwe,
 			Statement:            c.Statement,
 			Acknowledgement:      c.Acknowledgement,
-			Mitigation:           c.Mitigation,
+			Mitigation:           mitigation,
 			TempAffectedRelease:  c.TempAffectedRelease,
 			AffectedRelease:      releases,
 			PackageState:         states,

--- a/models/redhat.go
+++ b/models/redhat.go
@@ -31,7 +31,7 @@ type RedhatCVEJSON struct {
 	Cwe                  string         `json:"cwe"`
 	Statement            string         `json:"statement"`
 	Acknowledgement      string         `json:"acknowledgement"`
-	Mitigation           string         `json:"mitigation"`
+	Mitigation           RedhatMitigation         `json:"mitigation"`
 	TempAffectedRelease  interface{}    `json:"affected_release"` // affected_release is array or object
 	AffectedRelease      []RedhatAffectedRelease
 	TempPackageState     interface{} `json:"package_state"` // package_state is array or object
@@ -151,4 +151,8 @@ type RedhatPackageState struct {
 	FixState    string `json:"fix_state"`
 	PackageName string `json:"package_name"`
 	Cpe         string `json:"cpe"`
+}
+
+type RedhatMitigation struct {
+	Value	string `json:"value"`
 }


### PR DESCRIPTION
Fix another error related to type on field mitigation and closed to issue #30, here error log
when trying to 'fetch redhatapi':

```
Failed to fetch the CVE details.
err="json: cannot unmarshal object into Go struct field RedhatCVEJSON.mitigation of type string"
```