### PR TITLE
add(debian): impl GetFixedCvesDebian

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -22,6 +22,7 @@ type DB interface {
 	GetMicrosoftMulti([]string) map[string]models.MicrosoftCVE
 	GetUnfixedCvesRedhat(string, string, bool) map[string]models.RedhatCVE
 	GetUnfixedCvesDebian(string, string) map[string]models.DebianCVE
+	GetFixedCvesDebian(string, string) map[string]models.DebianCVE
 
 	InsertRedhat([]models.RedhatCVEJSON) error
 	InsertDebian(models.DebianJSON) error

--- a/db/redis.go
+++ b/db/redis.go
@@ -178,8 +178,17 @@ func (r *RedisDriver) GetUnfixedCvesRedhat(major, pkgName string, ignoreWillNotF
 	return
 }
 
-// GetUnfixedCvesDebian :
-func (r *RedisDriver) GetUnfixedCvesDebian(major, pkgName string) (m map[string]models.DebianCVE) {
+// GetUnfixedCvesDebian : get the CVEs related to debian_release.status = 'open', major, pkgName
+func (r *RedisDriver) GetUnfixedCvesDebian(major, pkgName string) map[string]models.DebianCVE {
+	return r.getCvesDebianWithFixStatus(major, pkgName, "open")
+}
+
+// GetFixedCvesDebian : get the CVEs related to debian_release.status = 'resolved', major, pkgName
+func (r *RedisDriver) GetFixedCvesDebian(major, pkgName string) map[string]models.DebianCVE {
+	return r.getCvesDebianWithFixStatus(major, pkgName, "resolved")
+}
+
+func (r *RedisDriver) getCvesDebianWithFixStatus(major, pkgName, fixStatus string) (m map[string]models.DebianCVE) {
 	m = map[string]models.DebianCVE{}
 	codeName, ok := debVerCodename[major]
 	if !ok {
@@ -206,7 +215,7 @@ func (r *RedisDriver) GetUnfixedCvesDebian(major, pkgName string) (m map[string]
 			}
 			rels := []models.DebianRelease{}
 			for _, rel := range pkg.Release {
-				if rel.ProductName == codeName && rel.Status == "open" {
+				if rel.ProductName == codeName && rel.Status == fixStatus {
 					rels = append(rels, rel)
 				}
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -45,6 +45,7 @@ func Start(logDir string, driver db.DB) error {
 	e.GET("/debian/cves/:id", getDebianCve(driver))
 	e.GET("/redhat/:release/pkgs/:name/unfixed-cves", getUnfixedCvesRedhat(driver))
 	e.GET("/debian/:release/pkgs/:name/unfixed-cves", getUnfixedCvesDebian(driver))
+	e.GET("/debian/:release/pkgs/:name/fixed-cves", getFixedCvesDebian(driver))
 
 	bindURL := fmt.Sprintf("%s:%s", viper.GetString("bind"), viper.GetString("port"))
 	log15.Info("Listening", "URL", bindURL)
@@ -96,6 +97,16 @@ func getUnfixedCvesDebian(driver db.DB) echo.HandlerFunc {
 		release := util.Major(c.Param("release"))
 		pkgName := c.Param("name")
 		cveDetail := driver.GetUnfixedCvesDebian(release, pkgName)
+		return c.JSON(http.StatusOK, &cveDetail)
+	}
+}
+
+// Handler
+func getFixedCvesDebian(driver db.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		release := util.Major(c.Param("release"))
+		pkgName := c.Param("name")
+		cveDetail := driver.GetFixedCvesDebian(release, pkgName)
 		return c.JSON(http.StatusOK, &cveDetail)
 	}
 }


### PR DESCRIPTION
refs. https://github.com/future-architect/vuls/pull/1053


*Description of changes:*
In Debian, it was necessary to obtain information on Fixed CVE as well as Unfixed CVE.

I ran `gost` in server mode and confirmed that fixed and unfixed CVEs can be fetched with curl respectively.

```terminal
$ curl http://127.0.0.1:1325/debian/10/pkgs/apt/unfixed-cves | jq "."
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   924  100   924    0     0   128k      0 --:--:-- --:--:-- --:--:--  128k
{
  "CVE-2011-3374": {
    "ID": 4100,
    "CveID": "CVE-2011-3374",
    "Scope": "local",
    "Description": "It was found that apt-key in apt, all versions, do not correctly validate gpg keys with the master keyring, leading to a potential man-in-the-middle attack.",
    "Package": [
      {
        "ID": 4599,
        "DebianCVEID": 4100,
        "PackageName": "apt",
        "Release": [
          {
            "ID": 14981,
            "DebianPackageID": 4599,
            "ProductName": "buster",
            "Status": "open",
            "FixedVersion": "",
            "Urgency": "unimportant",
            "Version": "1.8.2.1"
          }
        ]
      }
    ]
  },

$ curl http://127.0.0.1:1325/debian/10/pkgs/apt/fixed-cves | jq "."
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 10628    0 10628    0     0   415k      0 --:--:-- --:--:-- --:--:--  415k
{
  "CVE-2009-1300": {
    "ID": 9947,
    "CveID": "CVE-2009-1300",
    "Scope": "local",
    "Description": "apt 0.7.20 does not check when the date command returns an \"invalid date\" error, which can prevent apt from loading security updates in time zones for which DST occurs at midnight.",
    "Package": [
      {
        "ID": 11149,
        "DebianCVEID": 9947,
        "PackageName": "apt",
        "Release": [
          {
            "ID": 36340,
            "DebianPackageID": 11149,
            "ProductName": "buster",
            "Status": "resolved",
            "FixedVersion": "0.7.21",
            "Urgency": "not yet assigned",
            "Version": "1.8.2.1"
          }
        ]
      }
    ]
  },
```