### PR TITLE
remove log output of opening and removing db

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -35,7 +35,6 @@ func NewDB(dbType, dbPath string, debugSQL bool) (driver DB, locked bool, err er
 		return driver, false, err
 	}
 
-	log15.Info("Opening DB.", "db", driver.Name())
 	if locked, err := driver.OpenDB(dbType, dbPath, debugSQL); err != nil {
 		if locked {
 			return nil, true, err
@@ -43,7 +42,6 @@ func NewDB(dbType, dbPath string, debugSQL bool) (driver DB, locked bool, err er
 		return nil, false, err
 	}
 
-	log15.Info("Migrating DB.", "db", driver.Name())
 	if err := driver.MigrateDB(); err != nil {
 		log15.Error("Failed to migrate db.", "err", err)
 		return driver, false, err


### PR DESCRIPTION
I removed log output of `Opening DB` and `Migrating DB`  to make it easier to see.
