### PR TITLE
chore: change clone cache dir and error handling

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,7 +11,16 @@
 	test \
 	integration \
 	cov \
-	clean
+	clean \
+	build-integration \
+	clean-integration \
+	fetch-rdb \
+	fetch-redis \
+	diff-cveid \
+	diff-package \
+	diff-server-rdb \
+	diff-server-redis \
+	diff-server-rdb-redis
 
 SRCS = $(shell git ls-files '*.go')
 PKGS = $(shell go list ./...)

--- a/db/debian.go
+++ b/db/debian.go
@@ -14,23 +14,30 @@ import (
 // GetDebian :
 func (r *RDBDriver) GetDebian(cveID string) *models.DebianCVE {
 	c := models.DebianCVE{}
-	err := r.conn.Where(&models.DebianCVE{CveID: cveID}).First(&c).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		log15.Error("Failed to get Debian", "err", err)
-		return nil
+	if err := r.conn.Where(&models.DebianCVE{CveID: cveID}).First(&c).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			log15.Error("Failed to get Debian", "err", err)
+			return nil
+		}
+		return &models.DebianCVE{}
 	}
-	err = r.conn.Model(&c).Association("Package").Find(&c.Package)
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		log15.Error("Failed to get Debian", "err", err)
-		return nil
+
+	if err := r.conn.Model(&c).Association("Package").Find(&c.Package); err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			log15.Error("Failed to get Debian", "err", err)
+			return nil
+		}
+		return &models.DebianCVE{}
 	}
 
 	var newPkg []models.DebianPackage
 	for _, pkg := range c.Package {
-		err = r.conn.Model(&pkg).Association("Release").Find(&pkg.Release)
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			log15.Error("Failed to get Debian", "err", err)
-			return nil
+		if err := r.conn.Model(&pkg).Association("Release").Find(&pkg.Release); err != nil {
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				log15.Error("Failed to get Debian", "err", err)
+				return nil
+			}
+			return &models.DebianCVE{}
 		}
 		newPkg = append(newPkg, pkg)
 	}
@@ -141,11 +148,10 @@ func (r *RDBDriver) GetFixedCvesDebian(major, pkgName string) map[string]models.
 }
 
 func (r *RDBDriver) getCvesDebianWithFixStatus(major, pkgName, fixStatus string) map[string]models.DebianCVE {
-	m := map[string]models.DebianCVE{}
 	codeName, ok := debVerCodename[major]
 	if !ok {
 		log15.Error("Debian %s is not supported yet", "err", major)
-		return m
+		return nil
 	}
 
 	type Result struct {
@@ -153,31 +159,35 @@ func (r *RDBDriver) getCvesDebianWithFixStatus(major, pkgName, fixStatus string)
 	}
 
 	results := []Result{}
-	err := r.conn.
+	if err := r.conn.
 		Table("debian_packages").
 		Select("debian_cve_id").
 		Where("package_name = ?", pkgName).
-		Scan(&results).Error
-
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		if fixStatus == "open" {
-			log15.Error("Failed to get unfixed cves of Debian", "err", err)
-		} else {
-			log15.Error("Failed to get fixed cves of Debian", "err", err)
+		Scan(&results).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			if fixStatus == "open" {
+				log15.Error("Failed to get unfixed cves of Debian", "err", err)
+			} else {
+				log15.Error("Failed to get fixed cves of Debian", "err", err)
+			}
+			return nil
 		}
-		return m
+		return map[string]models.DebianCVE{}
 	}
 
+	m := map[string]models.DebianCVE{}
 	for _, res := range results {
 		debcve := models.DebianCVE{}
-		err := r.conn.
+		if err := r.conn.
 			Preload("Package.Release", "status = ? AND product_name = ?", fixStatus, codeName).
 			Preload("Package", "package_name = ?", pkgName).
 			Where(&models.DebianCVE{ID: res.DebianCveID}).
-			First(&debcve).Error
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			log15.Error("Failed to get DebianCVE", res.DebianCveID, err)
-			return m
+			First(&debcve).Error; err != nil {
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				log15.Error("Failed to get DebianCVE", res.DebianCveID, err)
+				return nil
+			}
+			return map[string]models.DebianCVE{}
 		}
 
 		if len(debcve.Package) != 0 {

--- a/db/redhat.go
+++ b/db/redhat.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -21,13 +22,13 @@ func (r *RDBDriver) GetAfterTimeRedhat(after time.Time) (allCves []models.Redhat
 
 	// TODO: insufficient
 	for _, a := range all {
-		if err = r.conn.Model(&a).Association("Cvss3").Find(&a.Cvss3); err != nil && err != gorm.ErrRecordNotFound {
+		if err = r.conn.Model(&a).Association("Cvss3").Find(&a.Cvss3); err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, err
 		}
-		if err = r.conn.Model(&a).Association("Details").Find(&a.Details); err != nil && err != gorm.ErrRecordNotFound {
+		if err = r.conn.Model(&a).Association("Details").Find(&a.Details); err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, err
 		}
-		if err = r.conn.Model(&a).Association("PackageState").Find(&a.PackageState); err != nil && err != gorm.ErrRecordNotFound {
+		if err = r.conn.Model(&a).Association("PackageState").Find(&a.PackageState); err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, err
 		}
 		allCves = append(allCves, a)
@@ -76,7 +77,7 @@ func (r *RDBDriver) GetUnfixedCvesRedhat(major, pkgName string, ignoreWillNotFix
 			Cpe:         cpe,
 			PackageName: pkgName,
 		}).Find(&pkgStats).Error
-	if err != nil && err != gorm.ErrRecordNotFound {
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		log15.Error("Failed to get unfixed cves of Redhat", "err", err)
 		return nil
 	}
@@ -97,7 +98,7 @@ func (r *RDBDriver) GetUnfixedCvesRedhat(major, pkgName string, ignoreWillNotFix
 			Preload("Details").
 			Preload("References").
 			Where(&models.RedhatCVE{ID: id}).First(&rhcve).Error
-		if err != nil && err != gorm.ErrRecordNotFound {
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 			log15.Error("Failed to get unfixed cves of Redhat", "err", err)
 			return nil
 		}

--- a/db/redhat.go
+++ b/db/redhat.go
@@ -51,6 +51,7 @@ func (r *RDBDriver) GetRedhat(cveID string) *models.RedhatCVE {
 	errs = util.DeleteRecordNotFound(errs)
 	if len(errs.GetErrors()) > 0 {
 		log15.Error("Failed to get RedhatCVE", "err", errs.Error())
+		return nil
 	}
 	return &c
 }
@@ -66,20 +67,21 @@ func (r *RDBDriver) GetRedhatMulti(cveIDs []string) map[string]models.RedhatCVE 
 
 // GetUnfixedCvesRedhat gets the unfixed CVEs.
 func (r *RDBDriver) GetUnfixedCvesRedhat(major, pkgName string, ignoreWillNotFix bool) map[string]models.RedhatCVE {
-	m := map[string]models.RedhatCVE{}
 	cpe := fmt.Sprintf("cpe:/o:redhat:enterprise_linux:%s", major)
 	pkgStats := []models.RedhatPackageState{}
 
 	// https://access.redhat.com/documentation/en-us/red_hat_security_data_api/0.1/html-single/red_hat_security_data_api/index#cve_format
-	err := r.conn.
+	if err := r.conn.
 		Not(map[string]interface{}{"fix_state": []string{"Not affected", "New"}}).
 		Where(&models.RedhatPackageState{
 			Cpe:         cpe,
 			PackageName: pkgName,
-		}).Find(&pkgStats).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		log15.Error("Failed to get unfixed cves of Redhat", "err", err)
-		return nil
+		}).Find(&pkgStats).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			log15.Error("Failed to get unfixed cves of Redhat", "err", err)
+			return nil
+		}
+		return map[string]models.RedhatCVE{}
 	}
 
 	redhatCVEIDs := map[int64]bool{}
@@ -87,9 +89,10 @@ func (r *RDBDriver) GetUnfixedCvesRedhat(major, pkgName string, ignoreWillNotFix
 		redhatCVEIDs[p.RedhatCVEID] = true
 	}
 
+	m := map[string]models.RedhatCVE{}
 	for id := range redhatCVEIDs {
 		rhcve := models.RedhatCVE{}
-		err = r.conn.
+		if err := r.conn.
 			Preload("Bugzilla").
 			Preload("Cvss").
 			Preload("Cvss3").
@@ -97,10 +100,12 @@ func (r *RDBDriver) GetUnfixedCvesRedhat(major, pkgName string, ignoreWillNotFix
 			Preload("PackageState").
 			Preload("Details").
 			Preload("References").
-			Where(&models.RedhatCVE{ID: id}).First(&rhcve).Error
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			log15.Error("Failed to get unfixed cves of Redhat", "err", err)
-			return nil
+			Where(&models.RedhatCVE{ID: id}).First(&rhcve).Error; err != nil {
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				log15.Error("Failed to get unfixed cves of Redhat", "err", err)
+				return nil
+			}
+			return map[string]models.RedhatCVE{}
 		}
 
 		pkgStats := []models.RedhatPackageState{}

--- a/db/ubuntu.go
+++ b/db/ubuntu.go
@@ -177,10 +177,11 @@ func (r *RDBDriver) GetFixedCvesUbuntu(ver, pkgName string) map[string]models.Ub
 }
 
 func (r *RDBDriver) getCvesUbuntuWithFixStatus(ver, pkgName string, fixStatus []string) map[string]models.UbuntuCVE {
+	m := map[string]models.UbuntuCVE{}
 	codeName, ok := ubuntuVerCodename[ver]
 	if !ok {
 		log15.Error("Ubuntu %s is not supported yet", "err", ver)
-		return nil
+		return m
 	}
 
 	type Result struct {
@@ -188,35 +189,30 @@ func (r *RDBDriver) getCvesUbuntuWithFixStatus(ver, pkgName string, fixStatus []
 	}
 
 	results := []Result{}
-	if err := r.conn.
+	err := r.conn.
 		Table("ubuntu_patches").
 		Select("ubuntu_cve_id").
 		Where("package_name = ?", pkgName).
-		Scan(&results).Error; err != nil {
-		if !errors.Is(err, gorm.ErrRecordNotFound) {
-			if fixStatus[0] == "released" {
-				log15.Error("Failed to get fixed cves of Ubuntu", "err", err)
-			} else {
-				log15.Error("Failed to get unfixed cves of Ubuntu", "err", err)
-			}
-			return nil
+		Scan(&results).Error
+
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		if fixStatus[0] == "released" {
+			log15.Error("Failed to get fixed cves of Ubuntu", "err", err)
+		} else {
+			log15.Error("Failed to get unfixed cves of Ubuntu", "err", err)
 		}
-		return map[string]models.UbuntuCVE{}
 	}
 
-	m := map[string]models.UbuntuCVE{}
 	for _, res := range results {
 		cve := models.UbuntuCVE{}
-		if err := r.conn.
+		err := r.conn.
 			Preload("Patches.ReleasePatches", "release_name = ? AND status IN (?)", codeName, fixStatus).
 			Preload("Patches", "package_name = ?", pkgName).
 			Where(&models.UbuntuCVE{ID: res.UbuntuCveID}).
-			First(&cve).Error; err != nil {
-			if !errors.Is(err, gorm.ErrRecordNotFound) {
-				log15.Error("Failed to getCvesUbuntuWithFixStatus", "err", err)
-				return nil
-			}
-			return map[string]models.UbuntuCVE{}
+			First(&cve).Error
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			log15.Error("Failed to getCvesUbuntuWithFixStatus", "err", err)
+			return m
 		}
 
 		var errs util.Errors
@@ -235,7 +231,7 @@ func (r *RDBDriver) getCvesUbuntuWithFixStatus(ver, pkgName string, fixStatus []
 		errs = util.DeleteRecordNotFound(errs)
 		if len(errs.GetErrors()) > 0 {
 			log15.Error("Failed to get Ubuntu", "err", errs.Error())
-			return nil
+			return map[string]models.UbuntuCVE{}
 		}
 
 		if len(cve.Patches) != 0 {

--- a/db/ubuntu.go
+++ b/db/ubuntu.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/inconshreveable/log15"
@@ -194,7 +195,7 @@ func (r *RDBDriver) getCvesUbuntuWithFixStatus(ver, pkgName string, fixStatus []
 		Where("package_name = ?", pkgName).
 		Scan(&results).Error
 
-	if err != nil && err != gorm.ErrRecordNotFound {
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		if fixStatus[0] == "released" {
 			log15.Error("Failed to get fixed cves of Ubuntu", "err", err)
 		} else {
@@ -209,7 +210,7 @@ func (r *RDBDriver) getCvesUbuntuWithFixStatus(ver, pkgName string, fixStatus []
 			Preload("Patches", "package_name = ?", pkgName).
 			Where(&models.UbuntuCVE{ID: res.UbuntuCveID}).
 			First(&cve).Error
-		if err != nil && err != gorm.ErrRecordNotFound {
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 			log15.Error("Failed to getCvesUbuntuWithFixStatus", "err", err)
 			return m
 		}

--- a/models/models.go
+++ b/models/models.go
@@ -5,7 +5,7 @@ import "gorm.io/gorm"
 // LatestSchemaVersion manages the Schema version used in the latest Gost.
 const LatestSchemaVersion = 2
 
-// FetchMeta has meta infomation about fetched security tracker
+// FetchMeta has meta information about fetched security tracker
 type FetchMeta struct {
 	gorm.Model    `json:"-"`
 	GostRevision  string

--- a/util/util.go
+++ b/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -56,7 +57,7 @@ func DeleteNil(errs []error) (new []error) {
 // DeleteRecordNotFound deletes gorm.ErrRecordNotFound in errs
 func DeleteRecordNotFound(errs []error) (new []error) {
 	for _, err := range errs {
-		if err != nil && err != gorm.ErrRecordNotFound {
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 			new = append(new, err)
 		}
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -188,25 +188,13 @@ func Major(osVer string) (majorVersion string) {
 	return strings.Split(osVer, ".")[0]
 }
 
-var cacheDir string
-
-// DefaultCacheDir set default cache dir
-func DefaultCacheDir() string {
+// CacheDir return cache dir path string
+func CacheDir() string {
 	tmpDir, err := os.UserCacheDir()
 	if err != nil {
 		tmpDir = os.TempDir()
 	}
-	return filepath.Join(tmpDir, "trivy")
-}
-
-// CacheDir return cache dir path string
-func CacheDir() string {
-	return cacheDir
-}
-
-// SetCacheDir set cache dir path
-func SetCacheDir(dir string) {
-	cacheDir = dir
+	return filepath.Join(tmpDir, "gost")
 }
 
 // FileWalk walks the file tree rooted at root


### PR DESCRIPTION
Change the method to evaluate ErrRecordNotFound as described in the following link.
https://gorm.io/docs/error_handling.html#ErrRecordNotFound

Also, vuln-list is now cloned to the cache dir.
