### PR TITLE
feat(redis): add expire option

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -24,6 +24,6 @@ func init() {
 	fetchCmd.PersistentFlags().Int("batch-size", 15, "The number of batch size to insert. NOTE: This Option does not work for dbtype: redis.")
 	_ = viper.BindPFlag("batch-size", fetchCmd.PersistentFlags().Lookup("batch-size"))
 
-	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys")
+	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys in seconds. If set to 0, the key is persistent.")
 	_ = viper.BindPFlag("expire", fetchCmd.PersistentFlags().Lookup("expire"))
 }

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -22,5 +22,6 @@ func init() {
 	viper.BindPFlag("threads", fetchCmd.PersistentFlags().Lookup("threads"))
 
 	fetchCmd.PersistentFlags().Int("batch-size", 15, "The number of batch size to insert. NOTE: This Option does not work for dbtype: redis.")
-	viper.BindPFlag("batch-size", fetchCmd.PersistentFlags().Lookup("batch-size"))
+	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys")
+	_ = viper.BindPFlag("expire", fetchCmd.PersistentFlags().Lookup("expire"))
 }

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -16,12 +16,14 @@ func init() {
 	RootCmd.AddCommand(fetchCmd)
 
 	fetchCmd.PersistentFlags().Int("wait", 0, "Interval between fetch (seconds)")
-	viper.BindPFlag("wait", fetchCmd.PersistentFlags().Lookup("wait"))
+	_ = viper.BindPFlag("wait", fetchCmd.PersistentFlags().Lookup("wait"))
 
 	fetchCmd.PersistentFlags().Int("threads", 5, "The number of threads to be used")
-	viper.BindPFlag("threads", fetchCmd.PersistentFlags().Lookup("threads"))
+	_ = viper.BindPFlag("threads", fetchCmd.PersistentFlags().Lookup("threads"))
 
 	fetchCmd.PersistentFlags().Int("batch-size", 15, "The number of batch size to insert. NOTE: This Option does not work for dbtype: redis.")
+	_ = viper.BindPFlag("batch-size", fetchCmd.PersistentFlags().Lookup("batch-size"))
+
 	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys")
 	_ = viper.BindPFlag("expire", fetchCmd.PersistentFlags().Lookup("expire"))
 }

--- a/cmd/microsoft.go
+++ b/cmd/microsoft.go
@@ -24,8 +24,7 @@ func init() {
 	fetchCmd.AddCommand(microsoftCmd)
 
 	microsoftCmd.PersistentFlags().String("apikey", "", "microsoft apikey")
-	viper.BindPFlag("apikey", microsoftCmd.PersistentFlags().Lookup("apikey"))
-	viper.SetDefault("apikey", "")
+	_ = viper.BindPFlag("apikey", microsoftCmd.PersistentFlags().Lookup("apikey"))
 }
 
 func fetchMicrosoft(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -29,10 +29,10 @@ func init() {
 	RootCmd.AddCommand(notifyCmd)
 
 	RootCmd.PersistentFlags().Bool("to-email", false, "Send notification via Email")
-	viper.BindPFlag("to-email", RootCmd.PersistentFlags().Lookup("to-email"))
+	_ = viper.BindPFlag("to-email", RootCmd.PersistentFlags().Lookup("to-email"))
 
 	RootCmd.PersistentFlags().Bool("to-slack", false, "Send notification via Slack")
-	viper.BindPFlag("to-slack", RootCmd.PersistentFlags().Lookup("to-slack"))
+	_ = viper.BindPFlag("to-slack", RootCmd.PersistentFlags().Lookup("to-slack"))
 }
 
 func executeNotify(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/redhatapi.go
+++ b/cmd/redhatapi.go
@@ -23,17 +23,14 @@ var redHatAPICmd = &cobra.Command{
 func init() {
 	fetchCmd.AddCommand(redHatAPICmd)
 
-	redHatAPICmd.PersistentFlags().String("after", "", "Fetch CVEs after the specified date (e.g. 2017-01-01) (default: 1970-01-01)")
-	viper.BindPFlag("after", redHatAPICmd.PersistentFlags().Lookup("after"))
-	viper.SetDefault("after", "1970-01-01")
+	redHatAPICmd.PersistentFlags().String("after", "1970-01-01", "Fetch CVEs after the specified date (e.g. 2017-01-01)")
+	_ = viper.BindPFlag("after", redHatAPICmd.PersistentFlags().Lookup("after"))
 
 	redHatAPICmd.PersistentFlags().String("before", "", "Fetch CVEs before the specified date (e.g. 2017-01-01)")
-	viper.BindPFlag("before", redHatAPICmd.PersistentFlags().Lookup("before"))
-	viper.SetDefault("before", "")
+	_ = viper.BindPFlag("before", redHatAPICmd.PersistentFlags().Lookup("before"))
 
 	redHatAPICmd.PersistentFlags().Bool("list-only", false, "")
-	viper.BindPFlag("list-only", redHatAPICmd.PersistentFlags().Lookup("list-only"))
-	viper.SetDefault("list-only", false)
+	_ = viper.BindPFlag("list-only", redHatAPICmd.PersistentFlags().Lookup("list-only"))
 }
 
 func fetchRedHatAPI(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -33,13 +33,13 @@ func init() {
 	RootCmd.AddCommand(registerCmd)
 
 	registerCmd.PersistentFlags().String("select-cmd", "fzf", "Select command")
-	viper.BindPFlag("select-cmd", registerCmd.PersistentFlags().Lookup("select-cmd"))
+	_ = viper.BindPFlag("select-cmd", registerCmd.PersistentFlags().Lookup("select-cmd"))
 
 	registerCmd.PersistentFlags().String("select-option", "--reverse", "Select command options")
-	viper.BindPFlag("select-option", registerCmd.PersistentFlags().Lookup("select-option"))
+	_ = viper.BindPFlag("select-option", registerCmd.PersistentFlags().Lookup("select-option"))
 
 	registerCmd.PersistentFlags().String("select-after", "", "Show CVEs after the specified date (e.g. 2017-01-01) (default: 30 days ago)")
-	viper.BindPFlag("select-after", registerCmd.PersistentFlags().Lookup("select-after"))
+	_ = viper.BindPFlag("select-after", registerCmd.PersistentFlags().Lookup("select-after"))
 }
 
 func executeRegister(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,26 +29,26 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.gost.yaml)")
 
 	RootCmd.PersistentFlags().String("log-dir", util.GetDefaultLogDir(), "/path/to/log")
-	viper.BindPFlag("log-dir", RootCmd.PersistentFlags().Lookup("log-dir"))
+	_ = viper.BindPFlag("log-dir", RootCmd.PersistentFlags().Lookup("log-dir"))
 
 	RootCmd.PersistentFlags().Bool("log-json", false, "output log as JSON")
-	viper.BindPFlag("log-json", RootCmd.PersistentFlags().Lookup("log-json"))
+	_ = viper.BindPFlag("log-json", RootCmd.PersistentFlags().Lookup("log-json"))
 
 	RootCmd.PersistentFlags().Bool("debug", false, "debug mode")
-	viper.BindPFlag("debug", RootCmd.PersistentFlags().Lookup("debug"))
+	_ = viper.BindPFlag("debug", RootCmd.PersistentFlags().Lookup("debug"))
 
 	RootCmd.PersistentFlags().Bool("debug-sql", false, "SQL debug mode")
-	viper.BindPFlag("debug-sql", RootCmd.PersistentFlags().Lookup("debug-sql"))
+	_ = viper.BindPFlag("debug-sql", RootCmd.PersistentFlags().Lookup("debug-sql"))
 
 	pwd := os.Getenv("PWD")
 	RootCmd.PersistentFlags().String("dbpath", filepath.Join(pwd, "gost.sqlite3"), "/path/to/sqlite3 or SQL connection string")
-	viper.BindPFlag("dbpath", RootCmd.PersistentFlags().Lookup("dbpath"))
+	_ = viper.BindPFlag("dbpath", RootCmd.PersistentFlags().Lookup("dbpath"))
 
 	RootCmd.PersistentFlags().String("dbtype", "sqlite3", "Database type to store data in (sqlite3, mysql, postgres or redis supported)")
-	viper.BindPFlag("dbtype", RootCmd.PersistentFlags().Lookup("dbtype"))
+	_ = viper.BindPFlag("dbtype", RootCmd.PersistentFlags().Lookup("dbtype"))
 
 	RootCmd.PersistentFlags().String("http-proxy", "", "http://proxy-url:port (default: empty)")
-	viper.BindPFlag("http-proxy", RootCmd.PersistentFlags().Lookup("http-proxy"))
+	_ = viper.BindPFlag("http-proxy", RootCmd.PersistentFlags().Lookup("http-proxy"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -22,10 +22,10 @@ func init() {
 	RootCmd.AddCommand(serverCmd)
 
 	serverCmd.PersistentFlags().String("bind", "127.0.0.1", "HTTP server bind to IP address")
-	viper.BindPFlag("bind", serverCmd.PersistentFlags().Lookup("bind"))
+	_ = viper.BindPFlag("bind", serverCmd.PersistentFlags().Lookup("bind"))
 
 	serverCmd.PersistentFlags().String("port", "1325", "HTTP server port number")
-	viper.BindPFlag("port", serverCmd.PersistentFlags().Lookup("port"))
+	_ = viper.BindPFlag("port", serverCmd.PersistentFlags().Lookup("port"))
 }
 
 func executeServer(cmd *cobra.Command, args []string) (err error) {

--- a/db/redis.go
+++ b/db/redis.go
@@ -436,8 +436,7 @@ func (r *RedisDriver) InsertRedhat(cveJSONs []models.RedhatCVEJSON) (err error) 
 	bar := pb.StartNew(len(cves))
 
 	for _, cve := range cves {
-		var pipe redis.Pipeliner
-		pipe = r.conn.Pipeline()
+		pipe := r.conn.Pipeline()
 		bar.Increment()
 
 		j, err := json.Marshal(cve)
@@ -445,33 +444,35 @@ func (r *RedisDriver) InsertRedhat(cveJSONs []models.RedhatCVEJSON) (err error) 
 			return fmt.Errorf("Failed to marshal json. err: %s", err)
 		}
 
-		if result := pipe.HSet(ctx, hashKeyPrefix+cve.Name, "RedHat", string(j)); result.Err() != nil {
+		key := hashKeyPrefix + cve.Name
+		if result := pipe.HSet(ctx, key, "RedHat", string(j)); result.Err() != nil {
 			return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
 		}
 		if expire > 0 {
-			if err := pipe.Expire(ctx, hashKeyPrefix+cve.Name, time.Duration(expire*uint(time.Second))).Err(); err != nil {
+			if err := pipe.Expire(ctx, key, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 				return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 			}
 		} else {
-			if err := pipe.Persist(ctx, hashKeyPrefix+cve.Name).Err(); err != nil {
+			if err := pipe.Persist(ctx, key).Err(); err != nil {
 				return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 			}
 		}
 
 		for _, pkg := range cve.PackageState {
+			key := zindRedHatPrefix + pkg.PackageName
 			if result := pipe.ZAdd(
 				ctx,
-				zindRedHatPrefix+pkg.PackageName,
+				key,
 				&redis.Z{Score: 0, Member: cve.Name},
 			); result.Err() != nil {
 				return fmt.Errorf("Failed to ZAdd pkg name. err: %s", result.Err())
 			}
 			if expire > 0 {
-				if err := pipe.Expire(ctx, zindRedHatPrefix+pkg.PackageName, time.Duration(expire*uint(time.Second))).Err(); err != nil {
+				if err := pipe.Expire(ctx, key, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 				}
 			} else {
-				if err := pipe.Persist(ctx, zindRedHatPrefix+pkg.PackageName).Err(); err != nil {
+				if err := pipe.Persist(ctx, key).Err(); err != nil {
 					return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 				}
 			}
@@ -495,8 +496,7 @@ func (r *RedisDriver) InsertDebian(cveJSONs models.DebianJSON) error {
 	bar := pb.StartNew(len(cves))
 
 	for _, cve := range cves {
-		var pipe redis.Pipeliner
-		pipe = r.conn.Pipeline()
+		pipe := r.conn.Pipeline()
 		bar.Increment()
 
 		j, err := json.Marshal(cve)
@@ -504,33 +504,35 @@ func (r *RedisDriver) InsertDebian(cveJSONs models.DebianJSON) error {
 			return fmt.Errorf("Failed to marshal json. err: %s", err)
 		}
 
-		if result := pipe.HSet(ctx, hashKeyPrefix+cve.CveID, "Debian", string(j)); result.Err() != nil {
+		key := hashKeyPrefix + cve.CveID
+		if result := pipe.HSet(ctx, key, "Debian", string(j)); result.Err() != nil {
 			return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
 		}
 		if expire > 0 {
-			if err := pipe.Expire(ctx, hashKeyPrefix+cve.CveID, time.Duration(expire*uint(time.Second))).Err(); err != nil {
+			if err := pipe.Expire(ctx, key, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 				return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 			}
 		} else {
-			if err := pipe.Persist(ctx, hashKeyPrefix+cve.CveID).Err(); err != nil {
+			if err := pipe.Persist(ctx, key).Err(); err != nil {
 				return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 			}
 		}
 
 		for _, pkg := range cve.Package {
+			key := zindDebianPrefix + pkg.PackageName
 			if result := pipe.ZAdd(
 				ctx,
-				zindDebianPrefix+pkg.PackageName,
+				key,
 				&redis.Z{Score: 0, Member: cve.CveID},
 			); result.Err() != nil {
 				return fmt.Errorf("Failed to ZAdd pkg name. err: %s", result.Err())
 			}
 			if expire > 0 {
-				if err := pipe.Expire(ctx, zindDebianPrefix+pkg.PackageName, time.Duration(expire*uint(time.Second))).Err(); err != nil {
+				if err := pipe.Expire(ctx, key, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 				}
 			} else {
-				if err := pipe.Persist(ctx, zindDebianPrefix+pkg.PackageName).Err(); err != nil {
+				if err := pipe.Persist(ctx, key).Err(); err != nil {
 					return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 				}
 			}
@@ -553,8 +555,7 @@ func (r *RedisDriver) InsertUbuntu(cveJSONs []models.UbuntuCVEJSON) (err error) 
 	bar := pb.StartNew(len(cves))
 
 	for _, cve := range cves {
-		var pipe redis.Pipeliner
-		pipe = r.conn.Pipeline()
+		pipe := r.conn.Pipeline()
 		bar.Increment()
 
 		j, err := json.Marshal(cve)
@@ -562,33 +563,35 @@ func (r *RedisDriver) InsertUbuntu(cveJSONs []models.UbuntuCVEJSON) (err error) 
 			return fmt.Errorf("Failed to marshal json. err: %s", err)
 		}
 
-		if result := pipe.HSet(ctx, hashKeyPrefix+cve.Candidate, "Ubuntu", string(j)); result.Err() != nil {
+		key := hashKeyPrefix + cve.Candidate
+		if result := pipe.HSet(ctx, key, "Ubuntu", string(j)); result.Err() != nil {
 			return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
 		}
 		if expire > 0 {
-			if err := pipe.Expire(ctx, hashKeyPrefix+cve.Candidate, time.Duration(expire*uint(time.Second))).Err(); err != nil {
+			if err := pipe.Expire(ctx, key, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 				return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 			}
 		} else {
-			if err := pipe.Persist(ctx, hashKeyPrefix+cve.Candidate).Err(); err != nil {
+			if err := pipe.Persist(ctx, key).Err(); err != nil {
 				return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 			}
 		}
 
 		for _, pkg := range cve.Patches {
+			key := zindUbuntuPrefix + pkg.PackageName
 			if result := pipe.ZAdd(
 				ctx,
-				zindUbuntuPrefix+pkg.PackageName,
+				key,
 				&redis.Z{Score: 0, Member: cve.Candidate},
 			); result.Err() != nil {
 				return fmt.Errorf("Failed to ZAdd pkg name. err: %s", result.Err())
 			}
 			if expire > 0 {
-				if err := pipe.Expire(ctx, zindUbuntuPrefix+pkg.PackageName, time.Duration(expire*uint(time.Second))).Err(); err != nil {
+				if err := pipe.Expire(ctx, key, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 				}
 			} else {
-				if err := pipe.Persist(ctx, zindUbuntuPrefix+pkg.PackageName).Err(); err != nil {
+				if err := pipe.Persist(ctx, key).Err(); err != nil {
 					return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 				}
 			}
@@ -610,22 +613,22 @@ func (r *RedisDriver) InsertMicrosoft(cveXMLs []models.MicrosoftXML, xls []model
 	cves, products := ConvertMicrosoft(cveXMLs, xls)
 	bar := pb.StartNew(len(cves))
 
-	var pipe redis.Pipeliner
-	pipe = r.conn.Pipeline()
+	pipe := r.conn.Pipeline()
 	for _, p := range products {
+		key := zindMicrosoftProductIDPrefix + p.ProductID
 		if result := pipe.ZAdd(
 			ctx,
-			zindMicrosoftProductIDPrefix+p.ProductID,
+			key,
 			&redis.Z{Score: 0, Member: p.ProductName},
 		); result.Err() != nil {
 			return fmt.Errorf("Failed to ZAdd kbID. err: %s", result.Err())
 		}
 		if expire > 0 {
-			if err := pipe.Expire(ctx, zindMicrosoftProductIDPrefix+p.ProductID, time.Duration(expire*uint(time.Second))).Err(); err != nil {
+			if err := pipe.Expire(ctx, key, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 				return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 			}
 		} else {
-			if err := pipe.Persist(ctx, zindMicrosoftProductIDPrefix+p.ProductID).Err(); err != nil {
+			if err := pipe.Persist(ctx, key).Err(); err != nil {
 				return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 			}
 		}
@@ -635,8 +638,7 @@ func (r *RedisDriver) InsertMicrosoft(cveXMLs []models.MicrosoftXML, xls []model
 	}
 
 	for _, cve := range cves {
-		var pipe redis.Pipeliner
-		pipe = r.conn.Pipeline()
+		pipe := r.conn.Pipeline()
 		bar.Increment()
 
 		j, err := json.Marshal(cve)
@@ -644,33 +646,35 @@ func (r *RedisDriver) InsertMicrosoft(cveXMLs []models.MicrosoftXML, xls []model
 			return fmt.Errorf("Failed to marshal json. err: %s", err)
 		}
 
-		if result := pipe.HSet(ctx, hashKeyPrefix+cve.CveID, "Microsoft", string(j)); result.Err() != nil {
+		key := hashKeyPrefix + cve.CveID
+		if result := pipe.HSet(ctx, key, "Microsoft", string(j)); result.Err() != nil {
 			return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
 		}
 		if expire > 0 {
-			if err := pipe.Expire(ctx, hashKeyPrefix+cve.CveID, time.Duration(expire*uint(time.Second))).Err(); err != nil {
+			if err := pipe.Expire(ctx, key, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 				return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 			}
 		} else {
-			if err := pipe.Persist(ctx, hashKeyPrefix+cve.CveID).Err(); err != nil {
+			if err := pipe.Persist(ctx, key).Err(); err != nil {
 				return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 			}
 		}
 
 		for _, msKBID := range cve.KBIDs {
+			key := zindMicrosoftKBIDPrefix + msKBID.KBID
 			if result := pipe.ZAdd(
 				ctx,
-				zindMicrosoftKBIDPrefix+msKBID.KBID,
+				key,
 				&redis.Z{Score: 0, Member: cve.CveID},
 			); result.Err() != nil {
 				return fmt.Errorf("Failed to ZAdd kbID. err: %s", result.Err())
 			}
 			if expire > 0 {
-				if err := pipe.Expire(ctx, zindMicrosoftKBIDPrefix+msKBID.KBID, time.Duration(expire*uint(time.Second))).Err(); err != nil {
+				if err := pipe.Expire(ctx, key, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 				}
 			} else {
-				if err := pipe.Persist(ctx, zindMicrosoftKBIDPrefix+msKBID.KBID).Err(); err != nil {
+				if err := pipe.Persist(ctx, key).Err(); err != nil {
 					return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 				}
 			}

--- a/db/redis.go
+++ b/db/redis.go
@@ -452,6 +452,10 @@ func (r *RedisDriver) InsertRedhat(cveJSONs []models.RedhatCVEJSON) (err error) 
 			if err := pipe.Expire(ctx, hashKeyPrefix+cve.Name, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 				return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 			}
+		} else {
+			if err := pipe.Persist(ctx, hashKeyPrefix+cve.Name).Err(); err != nil {
+				return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
+			}
 		}
 
 		for _, pkg := range cve.PackageState {
@@ -465,6 +469,10 @@ func (r *RedisDriver) InsertRedhat(cveJSONs []models.RedhatCVEJSON) (err error) 
 			if expire > 0 {
 				if err := pipe.Expire(ctx, zindRedHatPrefix+pkg.PackageName, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+				}
+			} else {
+				if err := pipe.Persist(ctx, zindRedHatPrefix+pkg.PackageName).Err(); err != nil {
+					return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 				}
 			}
 		}
@@ -503,6 +511,10 @@ func (r *RedisDriver) InsertDebian(cveJSONs models.DebianJSON) error {
 			if err := pipe.Expire(ctx, hashKeyPrefix+cve.CveID, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 				return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 			}
+		} else {
+			if err := pipe.Persist(ctx, hashKeyPrefix+cve.CveID).Err(); err != nil {
+				return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
+			}
 		}
 
 		for _, pkg := range cve.Package {
@@ -516,6 +528,10 @@ func (r *RedisDriver) InsertDebian(cveJSONs models.DebianJSON) error {
 			if expire > 0 {
 				if err := pipe.Expire(ctx, zindDebianPrefix+pkg.PackageName, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+				}
+			} else {
+				if err := pipe.Persist(ctx, zindDebianPrefix+pkg.PackageName).Err(); err != nil {
+					return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 				}
 			}
 		}
@@ -553,6 +569,10 @@ func (r *RedisDriver) InsertUbuntu(cveJSONs []models.UbuntuCVEJSON) (err error) 
 			if err := pipe.Expire(ctx, hashKeyPrefix+cve.Candidate, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 				return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 			}
+		} else {
+			if err := pipe.Persist(ctx, hashKeyPrefix+cve.Candidate).Err(); err != nil {
+				return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
+			}
 		}
 
 		for _, pkg := range cve.Patches {
@@ -566,6 +586,10 @@ func (r *RedisDriver) InsertUbuntu(cveJSONs []models.UbuntuCVEJSON) (err error) 
 			if expire > 0 {
 				if err := pipe.Expire(ctx, zindUbuntuPrefix+pkg.PackageName, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+				}
+			} else {
+				if err := pipe.Persist(ctx, zindUbuntuPrefix+pkg.PackageName).Err(); err != nil {
+					return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 				}
 			}
 		}
@@ -600,6 +624,10 @@ func (r *RedisDriver) InsertMicrosoft(cveXMLs []models.MicrosoftXML, xls []model
 			if err := pipe.Expire(ctx, zindMicrosoftProductIDPrefix+p.ProductID, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 				return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 			}
+		} else {
+			if err := pipe.Persist(ctx, zindMicrosoftProductIDPrefix+p.ProductID).Err(); err != nil {
+				return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
+			}
 		}
 	}
 	if _, err = pipe.Exec(ctx); err != nil {
@@ -623,6 +651,10 @@ func (r *RedisDriver) InsertMicrosoft(cveXMLs []models.MicrosoftXML, xls []model
 			if err := pipe.Expire(ctx, hashKeyPrefix+cve.CveID, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 				return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 			}
+		} else {
+			if err := pipe.Persist(ctx, hashKeyPrefix+cve.CveID).Err(); err != nil {
+				return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
+			}
 		}
 
 		for _, msKBID := range cve.KBIDs {
@@ -636,6 +668,10 @@ func (r *RedisDriver) InsertMicrosoft(cveXMLs []models.MicrosoftXML, xls []model
 			if expire > 0 {
 				if err := pipe.Expire(ctx, zindMicrosoftKBIDPrefix+msKBID.KBID, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+				}
+			} else {
+				if err := pipe.Persist(ctx, zindMicrosoftKBIDPrefix+msKBID.KBID).Err(); err != nil {
+					return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 				}
 			}
 		}

--- a/fetcher/redhat.go
+++ b/fetcher/redhat.go
@@ -27,7 +27,6 @@ func FetchRedHatVulnList() (entries []models.RedhatCVEJSON, err error) {
 	if err != nil {
 		return nil, xerrors.Errorf("error in vulnsrc clone or pull: %w", err)
 	}
-	log15.Debug("Failed to fetch the CVE details.", "err", err)
 
 	// Only last_updated.json
 	if len(updatedFiles) <= 1 {


### PR DESCRIPTION
Unlike RDBs, Redis does not lose old data. For users who do not want to be affected by old data remaining, it is possible to set a timeout deadline for keys using the Redis EXPIRE command.

# How Has This Been Tested?
```console
$ redis-cli -p 6379
127.0.0.1:6379> TTL "CVE#CVE-2009-1044"
(integer) 705
127.0.0.1:6379> TTL "CVE#R#hapi-fhir-utilities"
(integer) 652
127.0.0.1:6379> TTL "CVE#D#avahi"
(integer) 491
127.0.0.1:6379> TTL "CVE#U#gnome-desktop3"
(integer) 671
127.0.0.1:6379> TTL "CVE#K#935490"
(integer) 870
127.0.0.1:6379> TTL "CVE#P#11651"
(integer) 874

127.0.0.1:6379> keys CVE#*
(empty array)
```

# Reference
- https://redis.io/commands/expire